### PR TITLE
[image-refresh] Embedding remote images with Grafana's Text Panel, with interval-based refresh and cache busting

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,5 +2,6 @@
 
 ## unreleased
 - Add project boilerplate
+- Add snippet `image-refresh`
 
 ## x.x.x (2023-05-xx)

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,16 @@
 # Grafana Snippets
 
+
 ## About
 
-A collection of micro-solutions for customized Grafana addons, like embedding
+A collection of micro-solutions for customized [Grafana] addons, like embedding
 remote data of different kinds.
 
 
 ## Details
 
+- Ready-to-run implementations for [Grafana Text Panel]'s HTML display mode.
+
+
+[Grafana]: https://grafana.com/
+[Grafana Text Panel]: https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/text/

--- a/text-panel/image-refresh.html
+++ b/text-panel/image-refresh.html
@@ -14,38 +14,66 @@ Resources
 <head>
   <title>mois' Beecam</title>
 
+  <!--
+  Refresh image elements in HTML body, with cache busting.
+  The refresh interval unit is "seconds".
+  -->
+
   <script type="text/javascript">
+
       /**
-       * Refresh image in HTML body, with cache busting.
+       * Apply image refreshing to all `img` elements which have a `data-refresh` attribute.
        */
-      function updateImage() {
+      function registerRefreshingImages() {
+          const images = document.getElementsByTagName("img")
+          for (const image of images) {
+              if ("data-refresh" in image.attributes) {
+                  console.log(`Registering image refresh for: ${image.src}`)
+                  refreshImage(image)
+              }
+          }
+      }
 
-          // Acquire image object from DOM.
-          const image = document.getElementById("image")
+      /**
+       * Continuously refresh image element using an interval obtained
+       * from its `data-refresh` attribute. The unit is "seconds".
+       */
+      function refreshImage(image) {
 
-          // Define default settings.
+          // Get settings from DOM element.
+          const refresh_delay = Number.parseInt(image.attributes["data-refresh"].value)
+
+          // Remember original image URL.
           if (!image["data-src"]) image["data-src"] = image.src
-          const refresh_delay = Number.parseInt(image.attributes["data-refresh"].value) || 60
 
           // Compute URL, with cache busting query parameter.
           let cachebuster = (Math.random() * 10000000).toFixed()
           const image_url = image["data-src"] + "?nocache=" + cachebuster.toString()
 
           // Load image.
-          console.log(`Loading image at ${image_url}`)
+          console.log(`Refreshing image at ${image_url}`)
           image.src = image_url
 
           // Schedule next refresh cycle.
           console.log(`Scheduling refresh in ${refresh_delay} seconds`)
-          setTimeout(updateImage, refresh_delay * 1000);
+          setTimeout(refreshImage, refresh_delay * 1000, image)
       }
 
-      // Start a bit later, after the page's body has been loaded into the DOM.
-      setTimeout(updateImage, 1000);
+      /**
+       * Start a bit later, after the component's body has been loaded into the DOM.
+       *
+       * Using the `DOMContentLoaded` event does not work, because the page has
+       * been loaded already, while this component is only loaded inside a panel.
+       *
+       * TODO: Use corresponding Grafana events?
+       */
+      setTimeout(registerRefreshingImages, 1000)
+
   </script>
 
 </head>
 <body>
-  <img id="image" src="https://www.euse.de/honig/beescale/latest.jpg" data-refresh="10"/>
+  <img width="640" src="https://www.euse.de/honig/beescale/latest_b-cam1.jpg" data-refresh="10"/>
+  <img width="640" src="https://www.euse.de/honig/beescale/latest_b-cam2.jpg" data-refresh="15"/>
 </body>
 </html>

--- a/text-panel/image-refresh.html
+++ b/text-panel/image-refresh.html
@@ -21,13 +21,19 @@ Resources
 
   <script type="text/javascript">
 
+      // Track all image elements which should be refreshed, in order to prevent
+      // registering refresh handlers twice, for example when running multiple
+      // instances of this component.
+      window.refreshing_images = []
+
       /**
        * Apply image refreshing to all `img` elements which have a `data-refresh` attribute.
        */
       function registerRefreshingImages() {
           const images = document.getElementsByTagName("img")
           for (const image of images) {
-              if ("data-refresh" in image.attributes) {
+              if (!window.refreshing_images.includes(image) && "data-refresh" in image.attributes) {
+                  window.refreshing_images.push(image)
                   console.log(`Registering image refresh for: ${image.src}`)
                   refreshImage(image)
               }

--- a/text-panel/image-refresh.html
+++ b/text-panel/image-refresh.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<!--
+About
+=====
+Embedding remote images with Grafana's Text Panel, with interval-based refresh and cache busting.
+
+Resources
+=========
+- https://github.com/panodata/grafana-snippets
+- https://community.hiveeyes.org/t/panel-fur-webcam-bild-das-regelmassig-aktualisiert-wird/4921
+- https://community.grafana.com/t/refreshing-gif-image/49507/11
+-->
+<html>
+<head>
+  <title>mois' Beecam</title>
+
+  <script type="text/javascript">
+      /**
+       * Refresh image in HTML body, with cache busting.
+       */
+      function updateImage() {
+
+          // Acquire image object from DOM.
+          const image = document.getElementById("image")
+
+          // Define default settings.
+          if (!image["data-src"]) image["data-src"] = image.src
+          const refresh_delay = Number.parseInt(image.attributes["data-refresh"].value) || 60
+
+          // Compute URL, with cache busting query parameter.
+          let cachebuster = (Math.random() * 10000000).toFixed()
+          const image_url = image["data-src"] + "?nocache=" + cachebuster.toString()
+
+          // Load image.
+          console.log(`Loading image at ${image_url}`)
+          image.src = image_url
+
+          // Schedule next refresh cycle.
+          console.log(`Scheduling refresh in ${refresh_delay} seconds`)
+          setTimeout(updateImage, refresh_delay * 1000);
+      }
+
+      // Start a bit later, after the page's body has been loaded into the DOM.
+      setTimeout(updateImage, 1000);
+  </script>
+
+</head>
+<body>
+  <img id="image" src="https://www.euse.de/honig/beescale/latest.jpg" data-refresh="10"/>
+</body>
+</html>

--- a/text-panel/readme.md
+++ b/text-panel/readme.md
@@ -10,13 +10,17 @@ Ready-to-run implementations for [Grafana Text Panel]'s HTML display mode.
 
 ### Embedding remote images, with interval-based refresh and cache busting
 
-A HTML/JavaScript component, which applies refreshing to an image in the HTML body.
+A HTML/JavaScript component, which applies refreshing to all image elements in the
+HTML body, which have a `data-refresh` attribute.
+
 It will also handle cache busting properly, by appending a `?nocache=` query parameter
 with a random value to the image source URL.
 
-The refresh rate can be determined with the `data-refresh` attribute. The unit is "seconds".
+The refresh rate is the value of the `data-refresh` attribute. The unit is "seconds".
+Individual images can have individual refresh rates.
 ```html
-<img id="image" src="https://www.euse.de/honig/beescale/latest.jpg" data-refresh="30" />
+<img width="640" src="https://www.euse.de/honig/beescale/latest_b-cam1.jpg" data-refresh="10"/>
+<img width="640" src="https://www.euse.de/honig/beescale/latest_b-cam2.jpg" data-refresh="15"/>
 ```
 
 Reference: https://community.hiveeyes.org/t/panel-fur-webcam-bild-das-regelmassig-aktualisiert-wird/4921

--- a/text-panel/readme.md
+++ b/text-panel/readme.md
@@ -1,0 +1,25 @@
+# Grafana Text Panel snippets
+
+
+## About
+
+Ready-to-run implementations for [Grafana Text Panel]'s HTML display mode.
+
+
+## Details
+
+### Embedding remote images, with interval-based refresh and cache busting
+
+A HTML/JavaScript component, which applies refreshing to an image in the HTML body.
+It will also handle cache busting properly, by appending a `?nocache=` query parameter
+with a random value to the image source URL.
+
+The refresh rate can be determined with the `data-refresh` attribute. The unit is "seconds".
+```html
+<img id="image" src="https://www.euse.de/honig/beescale/latest.jpg" data-refresh="30" />
+```
+
+Reference: https://community.hiveeyes.org/t/panel-fur-webcam-bild-das-regelmassig-aktualisiert-wird/4921
+
+
+[Grafana Text Panel]: https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/text/


### PR DESCRIPTION
Dear @bee-mois,

coming from our excellent discussion at [^1], I am adding the `image-refresh` snippet for Grafana's Text Panel to this repository as a first example.

With kind regards,
Andreas.

[^1]: https://community.hiveeyes.org/t/panel-fur-webcam-bild-das-regelmassig-aktualisiert-wird/4921

/cc @wetterfrosch, @ClemensGruber, @thiasB, @msweef
