### PR TITLE
[markdown-remote] Rendering Markdown fetched from a remote location, with interval-based refresh and cache busting

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,5 +3,6 @@
 ## unreleased
 - Add project boilerplate
 - Add snippet `image-refresh`
+- Add snippet `markdown-remote`
 
 ## x.x.x (2023-05-xx)

--- a/text-panel/markdown-remote.html
+++ b/text-panel/markdown-remote.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<!--
+About
+=====
+Rendering Markdown fetched from a remote location, with interval-based refresh and cache busting.
+
+Resources
+=========
+- https://github.com/panodata/grafana-snippets
+- https://github.com/markedjs/marked
+- https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+
+Use-case
+========
+- https://community.hiveeyes.org/t/markdown-inhalte-im-grafana-einbetten/4941
+- https://community.hiveeyes.org/t/dwd-prognose-bienenflug/787
+- https://apicast.hiveeyes.org/
+- https://github.com/hiveeyes/apicast
+- https://apicast.hiveeyes.org/beeflight/forecast/germany/brandenburg/potsdam?format=table-markdown
+-->
+<html>
+<head>
+  <title>Beeflight forecast</title>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script type="text/javascript">
+      /**
+       * Render Markdown into HTML tag element, after fetching it from a remote location.
+       */
+      async function renderMarkdown() {
+
+          // Acquire element from DOM.
+          const element = document.getElementById("markdown")
+
+          // Define default settings.
+          //if (!element["data-src"]) element["data-src"] = element.src
+          const refresh_delay = Number.parseInt(element.attributes["data-refresh"].value) || 60
+
+          // Compute URL, with cache busting query parameter.
+          let cachebuster = (Math.random() * 10000000).toFixed()
+          const markdown_url = element.attributes["data-src"].value + "&nocache=" + cachebuster.toString()
+
+          // Load Markdown.
+          const response = await fetch(markdown_url)
+          const markdown = await response.text()
+
+          // Render Markdown.
+          element.innerHTML = marked.parse(markdown, {mangle: false, headerIds: false})
+
+          // Schedule next refresh cycle.
+          console.log(`Scheduling refresh in ${refresh_delay} seconds`)
+          setTimeout(renderMarkdown, refresh_delay * 1000)
+      }
+
+      // TODO: Will not work, because the page is already loaded - we are only inside a panel.
+      /*
+      window.addEventListener("DOMContentLoaded", () => {
+        renderMarkdown()
+      })
+      */
+
+      // Start a bit later, after the page's body has been loaded into the DOM.
+      setTimeout(renderMarkdown, 500)
+
+  </script>
+
+</head>
+<body>
+  <div id="markdown"
+       data-src="https://apicast.hiveeyes.org/beeflight/forecast/germany/brandenburg/potsdam?format=table-markdown"
+       data-refresh="3600"/>
+</body>
+</html>

--- a/text-panel/readme.md
+++ b/text-panel/readme.md
@@ -26,4 +26,20 @@ Individual images can have individual refresh rates.
 Reference: https://community.hiveeyes.org/t/panel-fur-webcam-bild-das-regelmassig-aktualisiert-wird/4921
 
 
+### Rendering Markdown from a remote location
+
+A HTML/JavaScript component, which loads Markdown content from a remote location,
+renders it using [marked], and applies refreshing and cache busting like the other example.
+
+Example:
+```html
+<div id="markdown"
+     data-src="http://apicast.hiveeyes.org/beeflight/forecast/germany/brandenburg/potsdam?format=table-markdown"
+     data-refresh="3600"/>
+```
+
+Reference: https://community.hiveeyes.org/t/markdown-inhalte-im-grafana-einbetten/4941
+
+
 [Grafana Text Panel]: https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/text/
+[marked]: https://github.com/markedjs/marked


### PR DESCRIPTION
Hi again,

coming from our excellent discussions at [^1][^2], I am adding the `markdown-remote` snippet for Grafana's Text Panel to this repository as a second example.

Let me know if you would like to see any adjustments, or if you can spot any flaws.

With kind regards,
Andreas.

[^1]: https://community.hiveeyes.org/t/dwd-prognose-bienenflug/787/29
[^2]: https://community.hiveeyes.org/t/markdown-inhalte-im-grafana-einbetten/4941

/cc @thiasB, @msweef, @ClemensGruber, @wetterfrosch
